### PR TITLE
Ignore case and spaces in key

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,4 +1,4 @@
-import { UserId, ZulipDest, ZulipOrig } from './zulip';
+import { ZulipOrig } from './zulip';
 
 export interface ParrotAdd {
   verb: 'parrotAdd';
@@ -39,13 +39,13 @@ export const parseCommand = (cmd: string, _orig: ZulipOrig): Command => {
   const split = cmd.split(' ').map(t => t.trim());
   const verb = split[0].toLowerCase();
   if (verb == 'add') {
-    if (!all.has(split[1])) return { verb: 'parrotAdd', key: split[1], value: split.slice(2).join(' ') };
+    if (!all.has(split[1])) return { verb: 'parrotAdd', key: split[1].toLowerCase(), value: split.slice(2).join(' ') };
   }
-  if (verb == 'del') return { verb: 'parrotDel', key: split[1] };
+  if (verb == 'del') return { verb: 'parrotDel', key: split[1].toLowerCase() };
   if (verb == 'hi' || verb == 'hello') return { verb: 'hi' };
   if (verb == 'help' || verb == 'halp' || verb == 'h') return { verb: 'help' };
   if (verb == 'play') return parsePlay(split);
-  return { verb: 'parrotGet', key: cmd };
+  return { verb: 'parrotGet', key: cmd.replace(/ /g, "").toLowerCase() };
 };
 
 const parsePlay = (words: string[]): Play => {


### PR DESCRIPTION
Since people keep getting this wrong.

Requires lower-casing all the existing keys. Not sure there's an easier way but running this should do it:

```ts
import { createNodeRedisClient } from 'handy-redis';

const client = createNodeRedisClient({
  port: parseInt(process.env.REDIS_PORT),
  password: process.env.REDIS_PASSWORD,
  db: process.env.REDIS_DB,
});
const key = 'zulip-lichess-parrot';

const main = async () => {
  const values = await client.hgetall(key);
  for (const [k, value] of values) {
    await client.hdel(key, k);
    await client.hset(key, [k.toLowerCase(), value]);
  }
};

main();
```