### PR TITLE
Re-register q when lost and timeout events.retrieve

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { parseCommand, Play } from './command';
 import { RedisParrot } from './parrot';
 import fetch from 'node-fetch';
 import { URLSearchParams } from 'url';
+import { sleep } from './util';
 
 (async () => {
   const z: Zulip = await zulipInit.default({ zuliprc: 'zuliprc' });
@@ -76,5 +77,8 @@ import { URLSearchParams } from 'url';
     );
   };
 
-  await messageLoop(z, messageHandler);
+  while (true) {
+    await messageLoop(z, messageHandler);
+    await sleep(10_000);
+  }
 })();

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,3 @@
+import { promisify } from 'util';
+
+export const sleep = promisify(setTimeout);


### PR DESCRIPTION
Same as ornicar/zulip-remind#12

Since Howard handles the zulip connection in the same way and iirc has similarly silently stopped responding in the past (I think at least once even at the same time).